### PR TITLE
has own property

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -40,7 +40,7 @@ function convert(detailHtml) {
       reject(new InvalidFormatError('There is no meta property'));
       return;
     }
-    if (!itemProps.hasOwnProperty('url') || !itemProps['url']) {
+    if (!Object.prototype.hasOwnProperty.call(itemProps, 'url') || !itemProps['url']) {
       reject(new InvalidFormatError('url in response is required'));
       return;
     }

--- a/src/merge-config.js
+++ b/src/merge-config.js
@@ -6,18 +6,18 @@ module.exports = function (url, defaultConfig, userConfig) {
   var opts = objectAssign({}, defaultConfig, userConfig);
   opts.url = url;
   var headerCandidate = [{}];
-  if (defaultConfig.hasOwnProperty('headers')) {
+  if (Object.prototype.hasOwnProperty.call(defaultConfig, 'headers')) {
     headerCandidate.push(defaultConfig.headers);
   }
-  if (userConfig.hasOwnProperty('headers')) {
+  if (Object.prototype.hasOwnProperty.call(userConfig, 'headers')) {
     headerCandidate.push(userConfig.headers);
   }
   opts.headers = objectAssign.apply(null, headerCandidate);
   var qsCandidate = [{}];
-  if (defaultConfig.hasOwnProperty('qs')) {
+  if (Object.prototype.hasOwnProperty.call(defaultConfig, 'qs')) {
     qsCandidate.push(defaultConfig.qs);
   }
-  if (userConfig.hasOwnProperty('qs')) {
+  if (Object.prototype.hasOwnProperty.call(userConfig, 'qs')) {
     qsCandidate.push(userConfig.qs);
   }
   opts.qs = objectAssign.apply(null, qsCandidate);


### PR DESCRIPTION
Use `Object.prototype.hasOwnProperty.call(target, 'value')` instead of `target.hasOwnProperty('value')`

see https://eslint.org/docs/rules/no-prototype-builtins

fixes #223 